### PR TITLE
Fixed typo in string[onlyonetoolallowed]

### DIFF
--- a/lang/en/enrol_lticoursetemplate.php
+++ b/lang/en/enrol_lticoursetemplate.php
@@ -74,4 +74,4 @@ $string['invalidshortname'] = 'Course shortname has not been set';
 $string['manager'] = 'User ID';
 $string['manager_help'] = 'Set user id that will run course backup/restore. By default it is your user id value but you can create a new user with required capabilities and set its id here.';
 $string['admindefaultvalues'] = 'Manager default values';
-$string['onlyonetoolallowed'] = 'Only onne tool can be creatad for a course';
+$string['onlyonetoolallowed'] = 'Only one tool can be created for a course';


### PR DESCRIPTION
Noticed a typo in one of the lang/eng strings that appears once the tool has been created.