### PR TITLE
Remove error catching causing unknown scope issues with Canvas environments

### DIFF
--- a/classes/local/ltiadvantage/entity/ags_info.php
+++ b/classes/local/ltiadvantage/entity/ags_info.php
@@ -97,9 +97,6 @@ class ags_info {
                 throw new \coding_exception('Scope must be a string value');
             }
             $key = array_search($scope, $validscopes);
-            if ($key === false) {
-                throw new \coding_exception("Scope '{$scope}' is invalid.");
-            }
             if ($key == 0) {
                 $this->lineitemscopes[] = self::SCOPES_LINEITEM_READONLY;
             } else if ($key == 1) {


### PR DESCRIPTION
When using the tool for a Moodle-to-Canvas connection the following unknown scope issue was encountered `PHP message: Default exception handler: Coding error detected, it must be fixed by a programmer: Scope 'https://canvas.instructure.com/lti-ags/progress/scope/show' is invalid.`

This exact issue is discussed [here](https://moodle.org/mod/forum/discuss.php?d=433941) for Moodle's in-built `enrol/lti` plugin. This was subsequently [patched](https://moodle.org/mod/forum/discuss.php?d=433941). Basically, the former behaviour is to hard-fail the launch for scopes that are not recognised (of which Canvas is one). However, known scopes are validated later anyway, so in the forum and the linked patch above, the suggestion is to remove lines 100-102 in `ags_info.php` causing the launch fail for unknown scopes. See also the [latest version of the Moodle plugin](https://github.com/moodle/moodle/blob/a97ddeb2a2c12d7294be4e2d44e75963bf756696/enrol/lti/classes/local/ltiadvantage/entity/ags_info.php#L106) for how the three lines no longer appear. 

This PR makes the suggested patch for the `enrol_lticoursetemplate` plugin. This enables the Moodle-to-Canvas connection to function as expected.